### PR TITLE
Add formal state to onSubmit

### DIFF
--- a/packages/formal/__tests__/use-formal.test.ts
+++ b/packages/formal/__tests__/use-formal.test.ts
@@ -217,6 +217,7 @@ describe('useFormal()', () => {
   })
 
   describe('.submit()', () => {
+    it('should pass formalState to onSubmit', async () => {})
     it('should call validate() before submitting', async () => {})
     it('should call onSubmit function passed with the current values', () => {})
     // Should we test isSubmitted and isSubmitting here? Since they

--- a/packages/formal/src/types.ts
+++ b/packages/formal/src/types.ts
@@ -1,8 +1,37 @@
 import { Schema as YupSchema } from 'yup'
 
+export interface FormalState<Schema> {
+  // Flags.
+  isDirty: boolean
+  isValid: boolean
+  isValidating: boolean
+  isSubmitting: boolean
+  isSubmitted: boolean
+
+  // State.
+  values: Schema
+  errors: FormalErrors<Schema>
+
+  // Callbacks.
+  change: (field: keyof Schema, value: any) => void
+  setErrors: (errors: FormalErrors<Schema>) => void
+  clearErrors: () => void
+  validate: () => void
+  reset: () => void
+  submit: () => void
+
+  // Getters.
+  getFieldProps: (field: keyof Schema) => FormalFieldProps
+  getResetButtonProps: () => FormalResetButtonProps
+  getSubmitButtonProps: () => FormalSubmitButtonProps
+}
+
 export interface FormalConfig<Schema> {
   schema?: YupSchema<Schema>
-  onSubmit: (values: Schema) => void
+  onSubmit: (
+    values: Schema,
+    formalState: Pick<FormalState<Schema>, 'clearErrors' | 'setErrors' | 'reset'>
+  ) => void
 }
 
 export type FormalErrors<Schema> = {
@@ -31,28 +60,3 @@ export interface FormalSubmitButtonProps {
   disabled: boolean
 }
 
-export interface FormalState<Schema> {
-  // Flags.
-  isDirty: boolean
-  isValid: boolean
-  isValidating: boolean
-  isSubmitting: boolean
-  isSubmitted: boolean
-
-  // State.
-  values: Schema
-  errors: FormalErrors<Schema>
-
-  // Callbacks.
-  change: (field: keyof Schema, value: any) => void
-  setErrors: (errors: FormalErrors<Schema>) => void
-  clearErrors: () => void
-  validate: () => void
-  reset: () => void
-  submit: () => void
-
-  // Getters.
-  getFieldProps: (field: keyof Schema) => FormalFieldProps
-  getResetButtonProps: () => FormalResetButtonProps
-  getSubmitButtonProps: () => FormalSubmitButtonProps
-}

--- a/packages/formal/src/use-formal.ts
+++ b/packages/formal/src/use-formal.ts
@@ -73,22 +73,6 @@ export default function useFormal<Schema>(
     clearErrors()
   }, [clearErrors, lastValues])
 
-  const submit = useCallback(async () => {
-    if (schema) {
-      try {
-        await validate()
-      } catch (error) {
-        return
-      }
-    }
-
-    setIsSubmitting(true)
-    await onSubmit(values)
-    setLastValues(values)
-    setIsSubmitted(true)
-    setIsSubmitting(false)
-  }, [schema, validate, onSubmit, values])
-
   const getFieldProps = useCallback(
     (field: keyof Schema) => ({
       disabled: isSubmitting,
@@ -113,6 +97,26 @@ export default function useFormal<Schema>(
     }),
     [errors, isDirty, isSubmitting, isValidating]
   )
+
+  const submit = useCallback(async () => {
+    if (schema) {
+      try {
+        await validate()
+      } catch (error) {
+        return
+      }
+    }
+
+    setIsSubmitting(true)
+    await onSubmit(values, {
+      setErrors,
+      clearErrors,
+      reset,
+    })
+    setLastValues(values)
+    setIsSubmitted(true)
+    setIsSubmitting(false)
+  }, [schema, onSubmit, values, validate, setErrors, clearErrors, reset])
 
   return {
     isDirty,


### PR DESCRIPTION
# Whats new?

<!-- What does this PR introduce to the codebase? -->

Pass formal state to `onSubmit` callback 

## Issue link

<!-- Link any issue here. -->

Closes #22

## Notes

<!-- Add any helpful note here. -->

What do you think? I could not unit-test it.