### PR TITLE
Throw errors when validation fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages/**/lib
 storybook-static
 *.log
 .env
+.idea

--- a/packages/formal/__tests__/use-formal.test.ts
+++ b/packages/formal/__tests__/use-formal.test.ts
@@ -1,5 +1,12 @@
 import { renderHook, cleanup, act } from 'react-hooks-testing-library'
+import * as yup from 'yup'
 import useFormal from '../src/use-formal'
+
+const schema = yup.object().shape({
+  firstName: yup.string().required(),
+  lastName: yup.string(),
+  email: yup.string().email().required(),
+})
 
 const initialValues = {
   firstName: 'Tony',
@@ -218,7 +225,47 @@ describe('useFormal()', () => {
 
     it('should call clearErrors() before validating', async () => {})
     it('should change isValidating only if schema contains async validations', () => {})
-    it('should call setErrors() if the validation failed', () => {})
+    it('should set the errors in state if the validation failed', async () => {
+      const { result } = renderHook(() =>
+        useFormal(
+          {},
+          {
+            schema,
+            onSubmit: values => values,
+          }
+        )
+      )
+
+      try {
+        await result.current.validate()
+      } catch (e) {
+        // ignore
+      }
+
+      expect(result.current.errors).toEqual(
+        {'email': 'email is a required field', 'firstName': 'firstName is a required field'}
+      )
+    })
+
+    it('should throw the errors if the validation failed', async () => {
+      const { result } = renderHook(() =>
+        useFormal(
+          {},
+          {
+            schema,
+            onSubmit: values => values,
+          }
+        )
+      )
+
+      try {
+        await result.current.validate()
+      } catch (e) {
+        expect(e).toEqual(
+          {'email': 'email is a required field', 'firstName': 'firstName is a required field'}
+        )
+      }
+    })
   })
 
   describe('.submit()', () => {

--- a/packages/formal/package.json
+++ b/packages/formal/package.json
@@ -35,7 +35,7 @@
     "@types/yup": "^0.26.12",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-hooks-testing-library": "^0.4.0",
+    "react-hooks-testing-library": "^0.4.1",
     "yup": "^0.27.0"
   }
 }

--- a/packages/formal/src/use-formal.ts
+++ b/packages/formal/src/use-formal.ts
@@ -60,8 +60,9 @@ export default function useFormal<Schema>(
         await schema[validationMethod](values, { abortEarly: false })
         resolve()
       } catch (error) {
-        setErrors(formatYupErrors<Schema>(error))
-        reject()
+        const formattedErrors = formatYupErrors<Schema>(error)
+        setErrors(formattedErrors)
+        reject(formattedErrors)
       } finally {
         if (isAsync) setIsValidating(false)
       }


### PR DESCRIPTION
chore: add extra tests on validation failure
chore: update react-hooks-testing-library

# Whats new?

This PR:

- ensures that, when validation fails, the errors object is actually thrown (as the API docs specify) instead of just throwing undefined;
- adds tests on the case above + on setting the errors object in the hook's state.

## Issue link

I haven't bothered to log the issue; I'll explain it here instead:

The [API Reference](https://github.com/kevinwolfcr/formal/blob/master/docs/api-reference.md#validate) specifies (or rather, implies) that when validation fails, an object is thrown containing the errors object. Unfortunately, nothing is thrown at all.

## Notes

A BIG warning here: due to [a limitation in React v16.8](https://github.com/facebook/react/issues/14769) several warnings are spouted out during tests. The tests themselves pass however. I believe we should tackle those warnings as React v16.9 lands with a fix.