### PR TITLE
Check if component is still mounted

### DIFF
--- a/packages/formal/src/utils.ts
+++ b/packages/formal/src/utils.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-syntax, @typescript-eslint/no-object-literal-type-assertion, no-prototype-builtins */
+import { useEffect, useRef } from 'react'
 import { Schema as YupSchema } from 'yup'
 
 import { FormalErrors } from './types'
@@ -36,4 +37,19 @@ export function schemaHasAsyncValidation<Schema>(
   }
 
   return false
+}
+
+// Check if component is still mounted
+export const useIsMounted = () => {
+  const ref = useRef<boolean>(false)
+
+  useEffect(() => {
+    ref.current = true
+
+    return () => {
+      ref.current = false
+    }
+  }, [])
+
+  return () => ref.current
 }


### PR DESCRIPTION
# Whats new?
Fix react warning:
> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.

Simple example that cause this error:
```js
formal = useFormal(initialValues, {
  schema: formSchema,
  onSubmit: () => new Promise((resolve) => {
    history.push('/other-route-without-this-component');
    resolve();
  }),
});
```

This warning possible after async validation or async submit, so I added check if component is still mounted after all async calls in hook.

## Issue link

N/A

## Notes

- Added useIsMounted hook
- No tests because right now is impossible test unmount without `act` errors (see this [issue](https://github.com/testing-library/react-testing-library/issues/281))